### PR TITLE
Only include index.js in node package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "test": "nyc mocha",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
+  "files": [
+    "index.js"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:yargs/y18n.git"


### PR DESCRIPTION
This removes the test folder from the node package, so that the package is smaller and flow-type does not try to validate the invalid json in the test folder.