### PR TITLE
feat(__): added tagged template literal support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
-  - "5"
+  - "6"
   - "node"
 after_success: npm run coverage

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ output:
 
 `my awesome string foo`
 
+_using tagged template literals_
+
+```js
+var __ = require('y18n').__
+var str = 'foo'
+
+console.log(__`my awesome string ${str}`)
+```
+
+output:
+
+`my awesome string foo`
+
 _pluralization support:_
 
 ```js
@@ -59,6 +72,10 @@ Create an instance of y18n with the config provided, options include:
 ### y18n.\_\_(str, arg, arg, arg)
 
 Print a localized string, `%s` will be replaced with `arg`s.
+
+This function can also be used as a tag for a template literal. You can use it
+like this: <code>__&#96;hello ${'world'}&#96;</code>. This will be equivalent to
+`__('hello %s', 'world')`.
 
 ### y18n.\_\_n(singularString, pluralString, count, arg, arg, arg)
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,9 @@ function Y18N (opts) {
 }
 
 Y18N.prototype.__ = function () {
+  if (typeof arguments[0] !== 'string') {
+    return this._taggedLiteral.apply(this, arguments)
+  }
   var args = Array.prototype.slice.call(arguments)
   var str = args.shift()
   var cb = function () {} // start with noop.
@@ -38,6 +41,19 @@ Y18N.prototype.__ = function () {
   }
 
   return util.format.apply(util, [this.cache[this.locale][str] || str].concat(args))
+}
+
+Y18N.prototype._taggedLiteral = function (parts) {
+  var args = arguments
+  var str = ''
+  parts.forEach(function (part, i) {
+    var arg = args[i + 1]
+    str += part
+    if (arg) {
+      str += '%s'
+    }
+  })
+  return this.__.apply(null, [str].concat([].slice.call(arguments, 1)))
 }
 
 Y18N.prototype._enqueueWrite = function (work) {

--- a/test/locales/pirate.json
+++ b/test/locales/pirate.json
@@ -1,5 +1,6 @@
 {
   "Hello": "Avast ye mateys!",
+  "Hi, %s %s!": "Yarr! Shiver me timbers, why 'tis %s %s!",
   "%d cat": {
     "one": "%d land catfish",
     "other": "%d land catfishes"

--- a/test/y18n-test.js
+++ b/test/y18n-test.js
@@ -30,6 +30,14 @@ describe('y18n', function () {
   })
 
   describe('__', function () {
+    it('can be used as a tag for template literals', function () {
+      var __ = y18n({
+        locale: 'pirate',
+        directory: path.join(__dirname, 'locales')
+      }).__
+
+      __`Hi, ${'Ben'} ${'Coe'}!`.should.equal('Yarr! Shiver me timbers, why \'tis Ben Coe!')
+    })
     it('uses replacements from the default locale if none is configured', function () {
       var __ = y18n({
         directory: path.join(__dirname, 'locales')


### PR DESCRIPTION
This is a nice little convenience wrapper for those of us with template literals available! It will load just fine on non-es2015 runtimes, too -- you just won't be able to _use_ it.

I couldn't figure out how to do something like this that's good enough for `__n`, so I just... didn't. I'd happily write one up if there were an obvious way to do so, though.