### PR TITLE
allow support for falsy values like 0 in tagged literal

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ Y18N.prototype._taggedLiteral = function (parts) {
   parts.forEach(function (part, i) {
     var arg = args[i + 1]
     str += part
-    if (arg) {
+    if (typeof arg !== 'undefined') {
       str += '%s'
     }
   })

--- a/test/y18n-test.js
+++ b/test/y18n-test.js
@@ -38,6 +38,14 @@ describe('y18n', function () {
 
       __`Hi, ${'Ben'} ${'Coe'}!`.should.equal('Yarr! Shiver me timbers, why \'tis Ben Coe!')
     })
+    it('can be used as a tag for template literals with falsy arguments', function () {
+      var __ = y18n({
+        locale: 'pirate',
+        directory: path.join(__dirname, 'locales')
+      }).__
+
+      __`Hi, ${'Ben'} ${''}!`.should.equal('Yarr! Shiver me timbers, why \'tis Ben !')
+    })
     it('uses replacements from the default locale if none is configured', function () {
       var __ = y18n({
         directory: path.join(__dirname, 'locales')


### PR DESCRIPTION
Without the `undefined` check the lookup key with %s won't be found when passing falsy values.