### PR TITLE
chore: add standard-version as npm run release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Coverage Status][coveralls-image]][coveralls-url]
 [![NPM version][npm-image]][npm-url]
 [![js-standard-style][standard-image]][standard-url]
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 
 The bare-bones internationalization library used by yargs.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "pretest": "standard",
     "test": "nyc mocha",
-    "coverage": "nyc report --reporter=text-lcov | coveralls"
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "release": "standard-version"
   },
   "repository": {
     "type": "git",
@@ -32,6 +33,7 @@
     "mocha": "^3.0.0",
     "nyc": "^11.0.1",
     "rimraf": "^2.5.0",
-    "standard": "^10.0.0-beta.0"
+    "standard": "^10.0.0-beta.0",
+    "standard-version": "^4.2.0"
   }
 }


### PR DESCRIPTION
Guess it's been a while since y18n was released. This just makes it easier to cut releases using a local dev dependency instead of requiring `standard-version` to be installed globally.

Also added the recommended badge to README :+1: