### PR TITLE
ci: remove coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 node_modules
 .nyc_output
+coverage
 package-lock.json

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,13 @@
+{
+  "exclude": [
+    "test/**"
+  ],
+  "reporter": [
+    "html",
+    "text"
+  ],
+  "branches": 96.5,
+  "lines": 100,
+  "functions": 94,
+  "statements": 100
+}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # y18n
 
-[![Build Status][travis-image]][travis-url]
-[![Coverage Status][coveralls-image]][coveralls-url]
 [![NPM version][npm-image]][npm-url]
 [![js-standard-style][standard-image]][standard-url]
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
@@ -105,10 +103,6 @@ post on why we think this is important](https://medium.com/the-node-js-collectio
 
 ISC
 
-[travis-url]: https://travis-ci.org/yargs/y18n
-[travis-image]: https://img.shields.io/travis/yargs/y18n.svg
-[coveralls-url]: https://coveralls.io/github/yargs/y18n
-[coveralls-image]: https://img.shields.io/coveralls/yargs/y18n.svg
 [npm-url]: https://npmjs.org/package/y18n
 [npm-image]: https://img.shields.io/npm/v/y18n.svg
 [standard-image]: https://img.shields.io/badge/code%20style-standard-brightgreen.svg

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "chai": "^4.0.1",
     "mocha": "^4.0.1",
     "nyc": "^15.1.0",
-    "rimraf": "^2.5.0",
+    "rimraf": "^3.0.2",
     "standard": "^10.0.0-beta.0",
     "standard-version": "^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -22,14 +22,13 @@
     "index.js"
   ],
   "scripts": {
-    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "coverage": "nyc report && nyc check-coverage",
     "release": "standard-version",
     "pretest": "standard",
     "test": "nyc mocha"
   },
   "devDependencies": {
     "chai": "^4.0.1",
-    "coveralls": "^3.0.0",
     "mocha": "^4.0.1",
     "nyc": "^11.0.1",
     "rimraf": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "chai": "^4.0.1",
     "mocha": "^4.0.1",
-    "nyc": "^11.0.1",
+    "nyc": "^15.1.0",
     "rimraf": "^2.5.0",
     "standard": "^10.0.0-beta.0",
     "standard-version": "^5.0.0"


### PR DESCRIPTION
This removes coveralls for the coverage NPM script. In the switch to GitHub actions as part of #89 the coverage script was broken with error `Couldn't find a repository matching this job` as a result of switching from travis CI.

See the renovate PR #82 as an example, https://github.com/yargs/y18n/pull/82/checks?check_run_id=943953063. This PR should resolve that issue.