### PR TITLE
fix(deno): update types for deno ^1.4.0

### DIFF
--- a/deno.ts
+++ b/deno.ts
@@ -1,5 +1,5 @@
 import { y18n as _y18n } from './build/lib/index.js'
-import { Y18NOpts } from './build/lib/index.d.ts'
+import type { Y18NOpts } from './build/lib/index.d.ts'
 import shim from './lib/platform-shims/deno.ts'
 
 const y18n = (opts: Y18NOpts) => {


### PR DESCRIPTION
In version 1.4 Deno adopted;

- the tsconfig setting [importsNotUsedAsValues](https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues) - https://github.com/denoland/deno/pull/7413

This requires the use of;
- type only imports for values which are only used as types (`importsNotUsedAsValues`)

I've added more details at https://github.com/yargs/yargs/issues/1771.


related prs:
- yargs https://github.com/yargs/yargs/pull/1772
- yargs-parser https://github.com/yargs/yargs-parser/pull/329
