### PR TITLE
fix(exports): node 13.0-13.6 require a string fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,13 @@
   "name": "y18n",
   "version": "5.0.2",
   "description": "the bare-bones internationalization library used by yargs",
-  "exports": {
-    "import": "./index.mjs",
-    "require": "./build/index.cjs"
-  },
+  "exports": [
+    {
+      "import": "./index.mjs",
+      "require": "./build/index.cjs"
+    },
+    "./build/index.cjs"
+  ],
   "type": "module",
   "module": "./build/lib/index.js",
   "keywords": [


### PR DESCRIPTION
package.json’s "engines" field claims yargs-parser supports node >= 10; node v13.0-v13.6 are included in this semver range. This change is required to be able to require() from yargs-parser successfully in these versions.

See https://github.com/yargs/yargs/pull/1776