### PR TITLE
fix(exports): node 13.0 and 13.1 require the dotted object form _with_ a string fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,15 @@
   "name": "y18n",
   "version": "5.0.3",
   "description": "the bare-bones internationalization library used by yargs",
-  "exports": [
-    {
-      "import": "./index.mjs",
-      "require": "./build/index.cjs"
-    },
-    "./build/index.cjs"
-  ],
+  "exports": {
+    ".": [
+      {
+        "import": "./index.mjs",
+        "require": "./build/index.cjs"
+      },
+      "./build/index.cjs"
+    ]
+  },
   "type": "module",
   "module": "./build/lib/index.js",
   "keywords": [


### PR DESCRIPTION
package.json’s "engines" field claims yargs-parser supports node >= 10; node v13.0 and v13.1 are included in this semver range. This change is required to be able to require() from yargs-parser successfully in these versions.

See https://github.com/yargs/yargs/pull/1776

Sorry I missed this in #103 (－‸ლ) 