### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -135,8 +135,8 @@ class Y18N {
   }
 
   updateLocale (obj: Locale) {
-    if ('__proto__' === this.locale){
-      throw new Error('Prototype pollution attempt detected');
+    if (this.locale === '__proto__') {
+      throw new Error('Prototype pollution attempt detected')
     }
 
     if (!this.cache[this.locale]) this._readLocaleFile()

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -136,7 +136,7 @@ class Y18N {
 
   updateLocale (obj: Locale) {
     if (this.locale === '__proto__') {
-      return;
+      return
     }
 
     if (!this.cache[this.locale]) this._readLocaleFile()

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -136,7 +136,7 @@ class Y18N {
 
   updateLocale (obj: Locale) {
     if (this.locale === '__proto__') {
-      throw new Error('Prototype pollution attempt detected')
+      return;
     }
 
     if (!this.cache[this.locale]) this._readLocaleFile()

--- a/test/y18n-test.cjs
+++ b/test/y18n-test.cjs
@@ -344,15 +344,14 @@ describe('y18n', function () {
       i18n.__('meow').should.equal('le meow')
     })
 
-    it('prevents prototype pollution', function() {
-      var i18n = y18n();
+    it('prevents prototype pollution', function () {
+      var i18n = y18n()
 
-      i18n.setLocale('__proto__');
+      i18n.setLocale('__proto__')
 
-      i18n.updateLocale({polluted: 'Yes! Its Polluted'});
+      i18n.updateLocale({ polluted: 'Yes! Its Polluted' })
 
-      expect({}.polluted).to.be.undefined;
-
+      expect({}.polluted).to.be.undefined
     })
   })
 

--- a/test/y18n-test.cjs
+++ b/test/y18n-test.cjs
@@ -351,7 +351,7 @@ describe('y18n', function () {
 
       i18n.updateLocale({ polluted: 'Yes! Its Polluted' })
 
-      expect({}.polluted).to.be.undefined
+      expect({}).to.not.have.property('polluted')
     })
   })
 

--- a/test/y18n-test.cjs
+++ b/test/y18n-test.cjs
@@ -343,6 +343,17 @@ describe('y18n', function () {
 
       i18n.__('meow').should.equal('le meow')
     })
+
+    it('prevents prototype pollution', function() {
+      var i18n = y18n();
+
+      i18n.setLocale('__proto__');
+
+      i18n.updateLocale({polluted: 'Yes! Its Polluted'});
+
+      expect({}.polluted).to.be.undefined;
+
+    })
   })
 
   describe('getLocale', function () {


### PR DESCRIPTION
https://huntr.dev/users/alromh87 has fixed the Prototype Pollution vulnerability 🔨. alromh87 has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/y18n/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/y18n/1/README.md

### User Comments:

### 📊 Metadata *

`y18n` is vulnerable to `Prototype Pollution`.
This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-y18n

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as _proto_.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoid setting magical attributes.

#### Note that in this case path is not expanded so constructor.prototype would not cause prototype pollution so filtering this magical attributes is not needed

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```js
// poc.js
const y18n = require('y18n')();
var obj = {}
console.log("Before : " + obj.polluted);
y18n.setLocale('__proto__');
y18n.updateLocale({polluted: 'Yes! Its Polluted'});
console.log("After : " + {}.polluted);
```

2. Execute the following commands in another terminal:

```bash
npm i y18n # Install affected module
node poc.js #  Run the PoC
```

3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

![Captura de pantalla de 2020-10-18 13-05-46](https://user-images.githubusercontent.com/7505980/96364310-b4935400-1142-11eb-9fcf-9b4b4b17912e.png)


### 🔥 Proof of Fix (PoF) *

After fix execution will block prototype pollution and throw an exception 

![y18nPOF](https://user-images.githubusercontent.com/7505980/96364236-739b3f80-1142-11eb-9a7d-0d8c0f2d6172.png)

### 👍 User Acceptance Testing (UAT)

After fix functionality is unafected