### PR TITLE
fix(webpack): skip readFileSync if not defined

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -120,7 +120,7 @@ class Y18N {
 
     // if a %d placeholder is provided, add quantity
     // to the arguments expanded by util.format.
-    var values: (string|number)[] = [str]
+    const values: (string|number)[] = [str]
     if (~str.indexOf('%d')) values.push(quantity)
 
     return shim.format.apply(shim.format, values.concat(args))
@@ -147,7 +147,7 @@ class Y18N {
   _taggedLiteral (parts: string[], ...args: string[]) {
     let str = ''
     parts.forEach(function (part, i) {
-      var arg = args[i + 1]
+      const arg = args[i + 1]
       str += part
       if (typeof arg !== 'undefined') {
         str += '%s'
@@ -162,16 +162,16 @@ class Y18N {
   }
 
   _processWriteQueue () {
-    var _this = this
-    var work = this.writeQueue[0]
+    const _this = this
+    const work = this.writeQueue[0]
 
     // destructure the enqueued work.
-    var directory = work.directory
-    var locale = work.locale
-    var cb = work.cb
+    const directory = work.directory
+    const locale = work.locale
+    const cb = work.cb
 
-    var languageFile = this._resolveLocaleFile(directory, locale)
-    var serializedLocale = JSON.stringify(this.cache[locale], null, 2)
+    const languageFile = this._resolveLocaleFile(directory, locale)
+    const serializedLocale = JSON.stringify(this.cache[locale], null, 2)
 
     shim.fs.writeFile(languageFile, serializedLocale, 'utf-8', function (err: Error) {
       _this.writeQueue.shift()
@@ -181,11 +181,14 @@ class Y18N {
   }
 
   _readLocaleFile () {
-    var localeLookup = {}
-    var languageFile = this._resolveLocaleFile(this.directory, this.locale)
+    let localeLookup = {}
+    const languageFile = this._resolveLocaleFile(this.directory, this.locale)
 
     try {
-      localeLookup = JSON.parse(shim.fs.readFileSync(languageFile, 'utf-8'))
+      // When using a bundler such as webpack, readFileSync may not be defined:
+      if (shim.fs.readFileSync) {
+        localeLookup = JSON.parse(shim.fs.readFileSync(languageFile, 'utf-8'))
+      }
     } catch (err) {
       if (err instanceof SyntaxError) {
         err.message = 'syntax error in ' + languageFile
@@ -199,10 +202,10 @@ class Y18N {
   }
 
   _resolveLocaleFile (directory: string, locale: string) {
-    var file = shim.resolve(directory, './', locale + '.json')
+    let file = shim.resolve(directory, './', locale + '.json')
     if (this.fallbackToLanguage && !this._fileExistsSync(file) && ~locale.lastIndexOf('_')) {
       // attempt fallback to language only
-      var languageFile = shim.resolve(directory, './', locale.split('_')[0] + '.json')
+      const languageFile = shim.resolve(directory, './', locale.split('_')[0] + '.json')
       if (this._fileExistsSync(languageFile)) file = languageFile
     }
     return file

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "author": "Ben Coe <bencoe@gmail.com>",
   "main": "./build/index.cjs",
   "scripts": {
-    "check": "standardx '**/*.ts' '**/*.cjs' '**/*.mjs'",
-    "fix": "standardx --fix '**/*.ts' '**/*.cjs' '**/*.mjs'",
+    "check": "standardx **/*.ts **/*.cjs **/*.mjs",
+    "fix": "standardx --fix **/*.ts **/*.cjs **/*.mjs",
     "pretest": "rimraf build && tsc -p tsconfig.test.json && cross-env NODE_ENV=test npm run build:cjs",
     "test": "c8 --reporter=text --reporter=html mocha test/*.cjs",
     "test:esm": "c8 --reporter=text --reporter=html mocha test/esm/*.mjs",
@@ -50,7 +50,7 @@
     "mocha": "^8.0.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.26.10",
-    "standardx": "^6.0.0",
+    "standardx": "^7.0.0",
     "ts-transform-default-export": "^1.0.2",
     "typescript": "^4.0.0"
   },

--- a/test/y18n-test.cjs
+++ b/test/y18n-test.cjs
@@ -19,7 +19,7 @@ describe('y18n', function () {
   describe('_readLocaleFile', function () {
     it('throws a helpful error if language file has invalid syntax', function () {
       expect(function () {
-        var __ = y18n({
+        const __ = y18n({
           locale: 'bad-locale',
           directory: path.join(__dirname, 'locales')
         }).__
@@ -31,7 +31,7 @@ describe('y18n', function () {
 
   describe('__', function () {
     it('can be used as a tag for template literals', function () {
-      var __ = y18n({
+      const __ = y18n({
         locale: 'pirate',
         directory: path.join(__dirname, 'locales')
       }).__
@@ -39,14 +39,14 @@ describe('y18n', function () {
       __`Hi, ${'Ben'} ${'Coe'}!`.should.equal('Yarr! Shiver me timbers, why \'tis Ben Coe!')
     })
     it('can be used as a tag for template literals with falsy arguments', function () {
-      var __ = y18n({
+      const __ = y18n({
         locale: 'pirate',
         directory: path.join(__dirname, 'locales')
       }).__
       __`Hi, ${'Ben'} ${''}!`.should.equal('Yarr! Shiver me timbers, why \'tis Ben !')
     })
     it('uses replacements from the default locale if none is configured', function () {
-      var __ = y18n({
+      const __ = y18n({
         directory: path.join(__dirname, 'locales')
       }).__
 
@@ -54,7 +54,7 @@ describe('y18n', function () {
     })
 
     it('uses replacements from the configured locale', function () {
-      var __ = y18n({
+      const __ = y18n({
         locale: 'pirate',
         directory: path.join(__dirname, 'locales')
       }).__
@@ -63,7 +63,7 @@ describe('y18n', function () {
     })
 
     it('uses language file if language_territory file does not exist', function () {
-      var __ = y18n({
+      const __ = y18n({
         locale: 'pirate_JM',
         directory: path.join(__dirname, 'locales')
       }).__
@@ -72,7 +72,7 @@ describe('y18n', function () {
     })
 
     it('does not fallback to language file if fallbackToLanguage is false', function () {
-      var __ = y18n({
+      const __ = y18n({
         locale: 'pirate_JM',
         fallbackToLanguage: false,
         updateFiles: false,
@@ -83,7 +83,7 @@ describe('y18n', function () {
     })
 
     it('uses strings as given if no matching locale files found', function () {
-      var __ = y18n({
+      const __ = y18n({
         locale: 'zz_ZZ',
         updateFiles: false,
         directory: path.join(__dirname, 'locales')
@@ -93,7 +93,7 @@ describe('y18n', function () {
     })
 
     it('expands arguments into %s placeholders', function () {
-      var __ = y18n({
+      const __ = y18n({
         directory: path.join(__dirname, 'locales')
       }).__
 
@@ -108,7 +108,7 @@ describe('y18n', function () {
       })
 
       it('returns the word immediately', function () {
-        var __ = y18n({
+        const __ = y18n({
           locale: 'fr',
           directory: path.join(__dirname, 'locales')
         }).__
@@ -117,13 +117,13 @@ describe('y18n', function () {
       })
 
       it('writes new word to locale file if updateFiles is true', function (done) {
-        var __ = y18n({
+        const __ = y18n({
           locale: 'fr_FR',
           directory: path.join(__dirname, 'locales')
         }).__
 
         __('banana', function (err) {
-          var locale = JSON.parse(fs.readFileSync('./test/locales/fr_FR.json', 'utf-8'))
+          const locale = JSON.parse(fs.readFileSync('./test/locales/fr_FR.json', 'utf-8'))
           locale.banana.should.equal('banana')
           return done(err)
         })
@@ -132,14 +132,14 @@ describe('y18n', function () {
       it('writes new word to language file if language_territory file does not exist', function (done) {
         fs.writeFileSync('./test/locales/fr.json', '{"meow": "le meow"}', 'utf-8')
 
-        var __ = y18n({
+        const __ = y18n({
           locale: 'fr_FR',
           directory: path.join(__dirname, 'locales')
         }).__
 
         __('meow').should.equal('le meow')
         __('banana', function (err) {
-          var locale = JSON.parse(fs.readFileSync('./test/locales/fr.json', 'utf-8'))
+          const locale = JSON.parse(fs.readFileSync('./test/locales/fr.json', 'utf-8'))
           locale.banana.should.equal('banana')
           return done(err)
         })
@@ -148,7 +148,7 @@ describe('y18n', function () {
       it('writes word to missing locale file, if no fallback takes place', function (done) {
         fs.writeFileSync('./test/locales/fr.json', '{"meow": "le meow"}', 'utf-8')
 
-        var __ = y18n({
+        const __ = y18n({
           locale: 'fr_FR',
           fallbackToLanguage: false,
           directory: path.join(__dirname, 'locales')
@@ -156,12 +156,12 @@ describe('y18n', function () {
 
         __('banana', function (err) {
           // 'banana' should be written to fr_FR.json
-          var locale = JSON.parse(fs.readFileSync('./test/locales/fr_FR.json', 'utf-8'))
+          const locale = JSON.parse(fs.readFileSync('./test/locales/fr_FR.json', 'utf-8'))
           locale.should.deep.equal({
             banana: 'banana'
           })
           // fr.json should remain untouched
-          var frJson = JSON.parse(fs.readFileSync('./test/locales/fr.json', 'utf-8'))
+          const frJson = JSON.parse(fs.readFileSync('./test/locales/fr.json', 'utf-8'))
           frJson.should.deep.equal({
             meow: 'le meow'
           })
@@ -170,7 +170,7 @@ describe('y18n', function () {
       })
 
       it('handles enqueuing multiple writes at the same time', function (done) {
-        var __ = y18n({
+        const __ = y18n({
           locale: 'fr',
           directory: path.join(__dirname, 'locales')
         }).__
@@ -179,7 +179,7 @@ describe('y18n', function () {
         __('banana', function () {
           __('foo')
           __('bar', function (err) {
-            var locale = JSON.parse(fs.readFileSync('./test/locales/fr.json', 'utf-8'))
+            const locale = JSON.parse(fs.readFileSync('./test/locales/fr.json', 'utf-8'))
             locale.apple.should.equal('apple')
             locale.banana.should.equal('banana')
             locale.foo.should.equal('foo')
@@ -190,7 +190,7 @@ describe('y18n', function () {
       })
 
       it('does not write the locale file if updateFiles is false', function (done) {
-        var __ = y18n({
+        const __ = y18n({
           locale: 'fr',
           updateFiles: false,
           directory: path.join(__dirname, 'locales')
@@ -206,7 +206,7 @@ describe('y18n', function () {
 
   describe('__n', function () {
     it('uses the singular form if quantity is 1', function () {
-      var __n = y18n({
+      const __n = y18n({
         directory: path.join(__dirname, 'locales')
       }).__n
 
@@ -214,7 +214,7 @@ describe('y18n', function () {
     })
 
     it('uses the plural form if quantity is greater than 1', function () {
-      var __n = y18n({
+      const __n = y18n({
         directory: path.join(__dirname, 'locales')
       }).__n
 
@@ -222,7 +222,7 @@ describe('y18n', function () {
     })
 
     it('allows additional arguments to be printed', function () {
-      var __n = y18n({
+      const __n = y18n({
         directory: path.join(__dirname, 'locales')
       }).__n
 
@@ -230,7 +230,7 @@ describe('y18n', function () {
     })
 
     it('allows an alternative locale to be set', function () {
-      var __n = y18n({
+      const __n = y18n({
         locale: 'pirate',
         directory: path.join(__dirname, 'locales')
       }).__n
@@ -241,12 +241,12 @@ describe('y18n', function () {
 
     // See: https://github.com/bcoe/yargs/pull/210
     it('allows a quantity placeholder to be provided in the plural but not singular form', function () {
-      var __n = y18n({
+      const __n = y18n({
         directory: path.join(__dirname, 'locales')
       }).__n
 
-      var singular = __n('There is one monkey in the %s', 'There are %d monkeys in the %s', 1, 'tree')
-      var plural = __n('There is one monkey in the %s', 'There are %d monkeys in the %s', 3, 'tree')
+      const singular = __n('There is one monkey in the %s', 'There are %d monkeys in the %s', 1, 'tree')
+      const plural = __n('There is one monkey in the %s', 'There are %d monkeys in the %s', 3, 'tree')
 
       singular.should.equal('There is one monkey in the tree')
       plural.should.equal('There are 3 monkeys in the tree')
@@ -260,7 +260,7 @@ describe('y18n', function () {
       })
 
       it('returns the pluralization immediately', function () {
-        var __n = y18n({
+        const __n = y18n({
           locale: 'fr',
           directory: path.join(__dirname, 'locales')
         }).__n
@@ -269,13 +269,13 @@ describe('y18n', function () {
       })
 
       it('writes to the locale file if updateFiles is true', function (done) {
-        var __n = y18n({
+        const __n = y18n({
           locale: 'fr',
           directory: path.join(__dirname, 'locales')
         }).__n
 
         __n('%d apple %s', '%d apples %s', 2, 'dude', function (err) {
-          var locale = JSON.parse(fs.readFileSync('./test/locales/fr.json', 'utf-8'))
+          const locale = JSON.parse(fs.readFileSync('./test/locales/fr.json', 'utf-8'))
           locale['%d apple %s'].one.should.equal('%d apple %s')
           locale['%d apple %s'].other.should.equal('%d apples %s')
           return done(err)
@@ -283,7 +283,7 @@ describe('y18n', function () {
       })
 
       it('does not write the locale file if updateFiles is false', function (done) {
-        var __n = y18n({
+        const __n = y18n({
           locale: 'fr',
           updateFiles: false,
           directory: path.join(__dirname, 'locales')
@@ -299,7 +299,7 @@ describe('y18n', function () {
 
   describe('setLocale', function () {
     it('switches the locale', function () {
-      var i18n = y18n({
+      const i18n = y18n({
         directory: path.join(__dirname, 'locales')
       })
 
@@ -317,7 +317,7 @@ describe('y18n', function () {
     })
 
     it('updates the locale with the new lookups provided', function () {
-      var i18n = y18n({
+      const i18n = y18n({
         locale: 'fr',
         directory: path.join(__dirname, 'locales')
       })
@@ -332,7 +332,7 @@ describe('y18n', function () {
     it('loads the locale from disk prior to updating the map', function () {
       fs.writeFileSync('./test/locales/fr.json', '{"meow": "le meow"}', 'utf-8')
 
-      var i18n = y18n({
+      const i18n = y18n({
         locale: 'fr',
         directory: path.join(__dirname, 'locales')
       })


### PR DESCRIPTION
Skip running `readFileSync` if it is not a function`. This allows `resolve.fallback.fs` to be set.