### PR TITLE
chore: export Y18N class

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -5,4 +5,5 @@ const y18n = (opts) => {
   return _y18n(opts, shim)
 }
 
+export { Y18N } from './build/lib/index.js'
 export default y18n

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -30,7 +30,7 @@ export interface PlatformShim {
 }
 
 let shim: PlatformShim
-class Y18N {
+export class Y18N {
   directory: string;
   updateFiles: boolean;
   locale: string;
@@ -189,7 +189,7 @@ class Y18N {
       if (shim.fs.readFileSync) {
         localeLookup = JSON.parse(shim.fs.readFileSync(languageFile, 'utf-8'))
       }
-    } catch (err) {
+    } catch (err: any) {
       if (err instanceof SyntaxError) {
         err.message = 'syntax error in ' + languageFile
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prepare": "npm run compile"
   },
   "devDependencies": {
-    "@types/node": "^14.6.4",
+    "@types/node": "^16.11.7",
     "@wessberg/rollup-plugin-ts": "^1.3.1",
     "c8": "^7.3.0",
     "chai": "^4.0.1",

--- a/test/esm/y18n-test.mjs
+++ b/test/esm/y18n-test.mjs
@@ -1,7 +1,7 @@
 /* global describe, it */
 
 import * as assert from 'assert'
-import y18n from '../../index.mjs'
+import y18n, { Y18N } from '../../index.mjs'
 
 describe('y18n', function () {
   it('__ smoke test', function () {
@@ -9,9 +9,20 @@ describe('y18n', function () {
       locale: 'pirate',
       directory: './test/locales'
     }).__
-
     assert.strictEqual(
       __`Hi, ${'Ben'} ${'Coe'}!`,
+      'Yarr! Shiver me timbers, why \'tis Ben Coe!'
+    )
+  })
+
+  it('explicit construction', () => {
+    const y18nOpts = {
+      locale: 'pirate',
+      directory: './test/locales'
+    }
+    const _y18n = new Y18N(y18nOpts)
+    assert.strictEqual(
+      _y18n.__`Hi, ${'Ben'} ${'Coe'}!`,
       'Yarr! Shiver me timbers, why \'tis Ben Coe!'
     )
   })

--- a/test/esm/y18n-test.mjs
+++ b/test/esm/y18n-test.mjs
@@ -15,7 +15,7 @@ describe('y18n', function () {
     )
   })
 
-  it('explicit construction', () => {
+  it('exposes an explicit construction', () => {
     const y18nOpts = {
       locale: 'pirate',
       directory: './test/locales'


### PR DESCRIPTION
allows users to explicitly construct their Y18N instance with their
own choice of shim.