### PR TITLE
fix(deno):`tsc` error and `deno` warnings

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -194,7 +194,7 @@ class Y18N {
         err.message = 'syntax error in ' + languageFile
       }
 
-      if (err.code === 'ENOENT') localeLookup = {}
+      if ((err as { code?: string }).code === 'ENOENT') localeLookup = {}
       else throw err
     }
 

--- a/lib/platform-shims/deno.ts
+++ b/lib/platform-shims/deno.ts
@@ -1,7 +1,7 @@
 /* global Deno */
 
-import { posix } from 'https://deno.land/std/path/mod.ts'
-import { sprintf } from 'https://deno.land/std/fmt/printf.ts'
+import { posix } from 'https://deno.land/std@0.159.0/path/mod.ts'
+import { sprintf } from 'https://deno.land/std@0.159.0/fmt/printf.ts'
 
 export default {
   fs: {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "prepare": "npm run compile"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^8.5.0",
     "@types/node": "^14.6.4",
-    "@wessberg/rollup-plugin-ts": "^1.3.1",
     "c8": "^7.3.0",
     "chai": "^4.0.1",
     "cross-env": "^7.0.2",
@@ -52,6 +52,7 @@
     "rollup": "^2.26.10",
     "standardx": "^7.0.0",
     "ts-transform-default-export": "^1.0.2",
+    "tslib": "^2.4.1",
     "typescript": "^4.0.0"
   },
   "files": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,4 @@
-import ts from '@wessberg/rollup-plugin-ts'
+import ts from '@rollup/plugin-typescript'
 import transformDefaultExport from 'ts-transform-default-export'
 
 const output = {


### PR DESCRIPTION
The current version causes Deno to report warnings when imported.
This PR pins the version to the current Deno std (0.159.0) and removes the warnings.

```shell
$ deno run -r deno.ts
Warning Implicitly using latest version (0.159.0) for https://deno.land/std/fmt/printf.ts
Warning Implicitly using latest version (0.159.0) for https://deno.land/std/path/mod.ts

$ git checkout fix.deno
Previous HEAD position was 7456792 fix: TypeScript compiler error (Object is 'unknown')
Switched to a new branch 'fix.deno'
Branch 'fix.deno' set up to track remote branch 'fix.deno' from 'origin'.

$ npm run compile
$ deno run -r deno.ts
```