### PR TITLE
fix: entrypoint specified in `module`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     ]
   },
   "type": "module",
-  "module": "./build/lib/index.js",
+  "module": "./index.mjs",
   "keywords": [
     "i18n",
     "internationalization",


### PR DESCRIPTION
This PR fixes https://github.com/yargs/y18n/issues/155.  
I made the entrypoint specified in the `module` field the same as `exports`.